### PR TITLE
Add typography component

### DIFF
--- a/packages/frontend/src/components/Typography/__snapshots__/test.tsx.snap
+++ b/packages/frontend/src/components/Typography/__snapshots__/test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Typography /> should render the Typography p as default 1`] = `
+.c0 {
+  font-size: 1rem;
+}
+
+<p
+  class="c0"
+>
+  Some text
+</p>
+`;

--- a/packages/frontend/src/components/Typography/index.stories.tsx
+++ b/packages/frontend/src/components/Typography/index.stories.tsx
@@ -1,0 +1,165 @@
+import { Meta, Story } from '@storybook/react'
+import Typography, { TypographyProps } from '.'
+
+export default {
+  title: 'Components/Typography',
+  component: Typography,
+  argTypes: {},
+} as Meta
+
+const Template: Story<TypographyProps> = (args) => (
+  <Typography {...args}>{args.children}</Typography>
+)
+
+export const Default = Template.bind({})
+Default.parameters = {}
+Default.args = {
+  children: 'Typography',
+}
+
+export const Hero = Template.bind({})
+Hero.parameters = {}
+Hero.args = {
+  as: 'h1',
+  size: '5xl',
+  weight: 'bold',
+  children: 'Hero',
+}
+
+export const Headline1 = Template.bind({})
+Headline1.parameters = {}
+Headline1.args = {
+  as: 'h1',
+  children: 'Heading 1',
+}
+
+export const Headline2 = Template.bind({})
+Headline2.parameters = {}
+Headline2.args = {
+  as: 'h2',
+  children: 'Heading 2',
+}
+
+export const Headline3 = Template.bind({})
+Headline3.parameters = {}
+Headline3.args = {
+  as: 'h3',
+  children: 'Heading 3',
+}
+
+export const Headline4 = Template.bind({})
+Headline4.parameters = {}
+Headline4.args = {
+  as: 'h4',
+  children: 'Heading 4',
+}
+
+export const Headline5 = Template.bind({})
+Headline5.parameters = {}
+Headline5.args = {
+  as: 'h5',
+  children: 'Heading 5',
+}
+
+export const Headline6 = Template.bind({})
+Headline6.parameters = {}
+Headline6.args = {
+  as: 'h6',
+  children: 'Heading 6',
+}
+
+export const Body1 = Template.bind({})
+Body1.parameters = {}
+Body1.args = {
+  as: 'span',
+  size: 'lg',
+  children: 'Body text large for big paragraphs.',
+}
+
+export const Body1Bold = Template.bind({})
+Body1Bold.parameters = {}
+Body1Bold.args = {
+  as: 'span',
+  size: 'lg',
+  weight: 'semibold',
+  children: 'Body text large for big paragraphs.',
+}
+
+export const Body2 = Template.bind({})
+Body2.parameters = {}
+Body2.args = {
+  size: 'md',
+  children: 'Body text normal, used for most readble content.',
+}
+
+export const Body2Bold = Template.bind({})
+Body2Bold.parameters = {}
+Body2Bold.args = {
+  size: 'md',
+  weight: 'medium',
+  children: 'Body text normal, used for most readble content.',
+}
+
+export const Caption = Template.bind({})
+Caption.parameters = {}
+Caption.args = {
+  size: 'sm',
+  children: 'Caption text normal, used for very small paragraphs.',
+}
+
+export const CaptionBold = Template.bind({})
+CaptionBold.parameters = {}
+CaptionBold.args = {
+  size: 'sm',
+  weight: 'medium',
+  children: 'Caption text bold, used for very small paragraphs.',
+}
+
+export const Caption2 = Template.bind({})
+Caption2.parameters = {}
+Caption2.args = {
+  size: 'xs',
+  children: 'Caption text, could be used for secondary links or navigation elements.',
+}
+
+export const Caption2Bold = Template.bind({})
+Caption2Bold.parameters = {}
+Caption2Bold.args = {
+  size: 'xs',
+  weight: 'medium',
+  children: 'Caption text bold, could be used for secondary links or navigation elements.',
+}
+
+export const HairlineLarge = Template.bind({})
+HairlineLarge.parameters = {}
+HairlineLarge.args = {
+  size: 'md',
+  weight: 'bold',
+  headline: true,
+  children: 'Hairline large',
+}
+
+export const HairlineSmall = Template.bind({})
+HairlineSmall.parameters = {}
+HairlineSmall.args = {
+  size: 'xs',
+  weight: 'bold',
+  headline: true,
+  children: 'Hairline small',
+}
+
+export const ButtonDefault = Template.bind({})
+ButtonDefault.parameters = {}
+ButtonDefault.args = {
+  size: 'md',
+  weight: 'bold',
+  children: 'Button Default',
+}
+
+export const ButtonSmall = Template.bind({})
+ButtonSmall.parameters = {}
+ButtonSmall.args = {
+  size: 'sm',
+  weight: 'bold',
+  children: 'Button small',
+}

--- a/packages/frontend/src/components/Typography/index.tsx
+++ b/packages/frontend/src/components/Typography/index.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react'
+import { Wrapper } from './styles'
+
+type Element = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'p' | 'text' | 'label'
+
+type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
+
+type Weight = 'normal' | 'medium' | 'semibold' | 'bold'
+
+export type TypographyProps = {
+  as?: Element
+  size?: Size
+  weight?: Weight
+  headline?: boolean
+  children: ReactNode
+}
+
+export default function Typography({
+  as = 'p',
+  size,
+  weight,
+  headline = false,
+  children,
+  ...rest
+}: TypographyProps) {
+  return (
+    <Wrapper {...rest} as={as} size={size} weight={weight} headline={headline}>
+      {children}
+    </Wrapper>
+  )
+}

--- a/packages/frontend/src/components/Typography/styles.ts
+++ b/packages/frontend/src/components/Typography/styles.ts
@@ -1,0 +1,99 @@
+import { Fragment } from 'react'
+import styled, { css } from 'styled-components'
+import { TypographyProps } from '.'
+
+const sizes = {
+  xs: css`
+    font-size: 0.75rem;
+  `,
+  sm: css`
+    font-size: 0.875rem;
+  `,
+  md: css`
+    font-size: 1rem;
+  `,
+  lg: css`
+    font-size: 1.5rem;
+  `,
+  xl: css`
+    font-size: 2rem;
+  `,
+  '2xl': css`
+    font-size: 2.5rem;
+  `,
+  '3xl': css`
+    font-size: 3rem;
+  `,
+  '4xl': css`
+    font-size: 4rem;
+  `,
+  '5xl': css`
+    font-size: 6rem;
+  `,
+}
+
+const weights = {
+  normal: css`
+    font-weight: 400;
+  `,
+  medium: css`
+    font-weight: 500;
+  `,
+  semibold: css`
+    font-weight: 600;
+  `,
+  bold: css`
+    font-weight: 700;
+  `,
+}
+
+const types = {
+  h1: css`
+    ${sizes['4xl']}
+    ${weights['bold']}
+  `,
+  h2: css`
+    ${sizes['3xl']}
+    ${weights['bold']}
+  `,
+  h3: css`
+    ${sizes['2xl']}
+    ${weights['bold']}
+  `,
+  h4: css`
+    ${sizes['xl']}
+    ${weights['bold']}
+  `,
+  h5: css`
+    ${sizes['lg']}
+    ${weights['bold']}
+  `,
+  h6: css`
+    ${sizes['md']}
+    ${weights['bold']}
+  `,
+  span: css`
+    ${sizes['md']}
+  `,
+  p: css`
+    ${sizes['md']}
+  `,
+  text: css`
+    ${sizes['md']}
+  `,
+  label: css`
+    ${sizes['md']}
+  `,
+}
+
+export const Wrapper = styled(Fragment)<Omit<TypographyProps, 'children'>>`
+  ${({ as, size, weight, headline }) => css`
+    ${as && types[as]}
+    ${size && sizes[size]}
+    ${weight && weights[weight]}
+    ${headline &&
+    css`
+      text-transform: uppercase;
+    `}
+  `}
+`

--- a/packages/frontend/src/components/Typography/test.tsx
+++ b/packages/frontend/src/components/Typography/test.tsx
@@ -84,6 +84,17 @@ describe('<Typography />', () => {
     })
   })
 
+  it('should render the Typography with normal weight', () => {
+    const { container } = render(<Typography weight="normal">Normal text</Typography>)
+
+    screen.getByText('Normal text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-weight': '400',
+    })
+  })
+
   it('should render the Typography with medium weight', () => {
     const { container } = render(<Typography weight="medium">Medium text</Typography>)
 

--- a/packages/frontend/src/components/Typography/test.tsx
+++ b/packages/frontend/src/components/Typography/test.tsx
@@ -1,0 +1,218 @@
+import { render, screen } from '../../utils/test-utils'
+
+import Typography from '.'
+
+describe('<Typography />', () => {
+  it('should render the Typography p as default', () => {
+    const { container } = render(<Typography>Some text</Typography>)
+
+    const p = screen.getByText('Some text')
+
+    expect(p).toBeInTheDocument()
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('should render the Typography as h1', () => {
+    const { container } = render(<Typography as="h1">Heading 1</Typography>)
+
+    screen.getByRole('heading', { name: /heading 1/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '4rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography as h2', () => {
+    const { container } = render(<Typography as="h2">Heading 2</Typography>)
+
+    screen.getByRole('heading', { name: /heading 2/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '3rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography as h3', () => {
+    const { container } = render(<Typography as="h3">Heading 3</Typography>)
+
+    screen.getByRole('heading', { name: /heading 3/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '2.5rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography as h4', () => {
+    const { container } = render(<Typography as="h4">Heading 4</Typography>)
+
+    screen.getByRole('heading', { name: /heading 4/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '2rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography as h5', () => {
+    const { container } = render(<Typography as="h5">Heading 5</Typography>)
+
+    screen.getByRole('heading', { name: /heading 5/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '1.5rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography as h6', () => {
+    const { container } = render(<Typography as="h6">Heading 6</Typography>)
+
+    screen.getByRole('heading', { name: /heading 6/i })
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '1rem',
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography with medium weight', () => {
+    const { container } = render(<Typography weight="medium">Medium text</Typography>)
+
+    screen.getByText('Medium text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-weight': '500',
+    })
+  })
+
+  it('should render the Typography with semibold weight', () => {
+    const { container } = render(<Typography weight="semibold">Semibold text</Typography>)
+
+    screen.getByText('Semibold text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-weight': '600',
+    })
+  })
+
+  it('should render the Typography with bold weight', () => {
+    const { container } = render(<Typography weight="bold">Bold text</Typography>)
+
+    screen.getByText('Bold text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-weight': '700',
+    })
+  })
+
+  it('should render the Typography with an extra small size', () => {
+    const { container } = render(<Typography size="xs">Extra small text</Typography>)
+
+    screen.getByText('Extra small text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '0.75rem',
+    })
+  })
+
+  it('should render the Typography with a small size', () => {
+    const { container } = render(<Typography size="sm">Small text</Typography>)
+
+    screen.getByText('Small text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '0.875rem',
+    })
+  })
+
+  it('should render the Typography with a medium size', () => {
+    const { container } = render(<Typography size="md">Medium text</Typography>)
+
+    screen.getByText('Medium text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '1rem',
+    })
+  })
+
+  it('should render the Typography with a large size', () => {
+    const { container } = render(<Typography size="lg">Large text</Typography>)
+
+    screen.getByText('Large text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '1.5rem',
+    })
+  })
+
+  it('should render the Typography with an extra large size', () => {
+    const { container } = render(<Typography size="xl">Extra large text</Typography>)
+
+    screen.getByText('Extra large text')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '2rem',
+    })
+  })
+
+  it('should render the Typography with an extra large 2x size', () => {
+    const { container } = render(<Typography size="2xl">Extra large 2x</Typography>)
+
+    screen.getByText('Extra large 2x')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '2.5rem',
+    })
+  })
+
+  it('should render the Typography with an extra large 3x size', () => {
+    const { container } = render(<Typography size="3xl">Extra large 3x</Typography>)
+
+    screen.getByText('Extra large 3x')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '3rem',
+    })
+  })
+
+  it('should render the Typography with an extra large 4x size', () => {
+    const { container } = render(<Typography size="4xl">Extra large 4x</Typography>)
+
+    screen.getByText('Extra large 4x')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '4rem',
+    })
+  })
+
+  it('should render the Typography with an extra large 5x size', () => {
+    const { container } = render(<Typography size="5xl">Extra large 5x</Typography>)
+
+    screen.getByText('Extra large 5x')
+
+    expect(container.firstChild).toBeInTheDocument()
+    expect(container.firstChild).toHaveStyle({
+      'font-size': '6rem',
+    })
+  })
+})

--- a/packages/frontend/src/elements/Divider/__snapshots__/test.tsx.snap
+++ b/packages/frontend/src/elements/Divider/__snapshots__/test.tsx.snap
@@ -14,18 +14,3 @@ exports[`<Divider /> should render the Divider with a light height 1`] = `
   role="separator"
 />
 `;
-
-exports[`<Section /> should render the Divider with a light height 1`] = `
-.c0 {
-  border: 0;
-  height: 1px;
-  background: #E6E8EC;
-}
-
-<hr
-  aria-hidden="true"
-  class="c0"
-  height="light"
-  role="separator"
-/>
-`;


### PR DESCRIPTION
## What is the reffered issue?

Issue: #53 

## What does this do?

<img width="190" alt="typography-component-full" src="https://user-images.githubusercontent.com/16243531/125026498-1aba6100-e05b-11eb-97c1-5c7d6254bf98.png">

## What does it affect?

Add a new component with tests

## Any debts to pay? (optional)

No debt to be paid, however probably some components that currently have static text/typographic style will need to be updated to use this component.

## Review Checklist

- [x] Added and/or modified tests for affected areas
- [x] Ready to review
- [x] Ready to merge
